### PR TITLE
Npm start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,10 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
-# Dependency directories
+# Dependency directories and files
 node_modules
 jspm_packages
+package-lock.json
 
 # Optional npm cache directory
 .npm
@@ -36,4 +37,3 @@ jspm_packages
 /public/css
 /public/js
 /public/img
-

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install
 2 - Para rodar o projeto em [http://localhost:3000](http://localhost:3000):
 
 ```
-$ gulp
+$ npm start
 ```
 
 ## Outros comandos úteis
@@ -38,4 +38,3 @@ $ gulp
 * **`gulp build`** - executa as tasks de css-rev e js-rev
 * **`gulp image-minify`** - compacta as imagens da pasta src/images e coloca na dist/img
 * **`gulp default`** - executa todas as tasks e levanta o ambiente (localhost)
-


### PR DESCRIPTION
Tentei rodar o `gulp` porém como não tenho ele instalado de maneira global não foi possível executar como alternativa a isso tem a opção de usar o npm start que utiliza o `gulp` instalado no `node_modules` que me parece mais adequado.
