### PR TITLE
Bug/copy og image

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/src/_scss/2.base/_images.scss
+++ b/src/_scss/2.base/_images.scss
@@ -2,3 +2,8 @@ img {
   max-width: 100%;
   font-style: italic; /* fancy broken image alt text */
 }
+
+/* make sure images used in html are added to dist (see https://stackoverflow.com/a/48727477/1712589) */
+._images-opengraph {
+  background-image: url('../images/afropython-image.png');
+}


### PR DESCRIPTION

**Qual é o propósito deste Pull Request?**

Copiar corretamente a imagem usada para opengraph (facebook, etc) ao publicar o side. O site atual não exibe imagem, como pode ser visto na ferramente de depuração do facebook (https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fafropython.org%2F)

**O que foi feito para alcançar esse propósito?**

Adicionada uma classe css com a imagem de background. O webpack copia por padrão imagens usadas nos estilos.

**Como testar se isso realmente funciona?**

Rode o site localmente e acesse http://localhost:8080/images/afropython-image.png

**TODO**

- [ ] Deploy após a aceitação do PR.
